### PR TITLE
Fix Android crash when enabling Auto Upload by updating flutter_photo_manager library

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -115,6 +115,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   file:
     dependency: transitive
     description:
@@ -262,7 +269,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.7.0"
   path_provider:
     dependency: transitive
     description:
@@ -311,7 +318,7 @@ packages:
       name: photo_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.5.8"
   photo_view:
     dependency: "direct main"
     description:
@@ -354,13 +361,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
   rxdart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   esys_flutter_share: ^1.0.2
   crypto: ^2.1.3
   flutter_secure_storage: ^3.3.1
-  photo_manager: ^0.4.8
+  photo_manager: ^0.5.8
   flutter_image_compress: ^0.6.5+1
   device_info: ^0.4.1+5
   video_player: '>=0.10.11+2 <2.0.0'


### PR DESCRIPTION
PhotoPrism Android app would crash once enabling Auto Upload in the setting page. The stack trace in the logcat is below. Reloading the app and accessing the Setting page would also crash the app with the same stack trace.

Fix: Updating the flutter_photo_manager library version fixes the crash. 

pubspec.lock changes were auto-generated during building and testing fix. 
Please let me know if I can provide any other information or further testing.

Thanks

`
java.lang.IllegalStateException: galleryName must not be null	
at top.kikt.imagescanner.core.utils.AndroidQDBUtils.getGalleryList(AndroidQDBUtils.kt:66)	
at top.kikt.imagescanner.core.PhotoManager.getGalleryList(PhotoManager.kt:42)	
at top.kikt.imagescanner.core.PhotoManagerPlugin$onHandlePermissionResult$1.invoke(PhotoManagerPlugin.kt:165)	
at top.kikt.imagescanner.core.PhotoManagerPlugin$onHandlePermissionResult$1.invoke(PhotoManagerPlugin.kt:23)	
at top.kikt.imagescanner.core.PhotoManagerPlugin$sam$java_lang_Runnable$0.run(Unknown Source:2)	
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)	
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)	
at java.lang.Thread.run(Thread.java:919)	
` 