### PR TITLE
Fix CI failure by bumping Flutter version

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
           java-version: "12.x"
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: "1.17.x"
+          flutter-version: "1.22.x"
           channel: "stable"
       - run: flutter format --dry-run --set-exit-if-changed lib
       - run: flutter analyze


### PR DESCRIPTION
Fixes https://github.com/photoprism/photoprism-mobile/issues/84

I thought it'd make sense to have it match the version specified here:
https://github.com/photoprism/photoprism-mobile/blob/e41abfe899bac58ca73e056a95b9955bfd3a64b6/.github/workflows/main.yml#L15