### PR TITLE
Filter and sort dialog rework

### DIFF
--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -23,7 +23,7 @@
   "cancel": "Abbrechen",
   "save": "Speichern",
   "apply": "Übernehmen",
-  "set_as_default": "Als Standard spreichern",
+  "set_as_default": "Als Standard speichern",
   "show_log": "Log anzeigen",
   "clear_log": "Log löschen",
   "auto_upload": "Automatisches Hochladen",
@@ -36,5 +36,8 @@
   "show_uploaded_photos_list": "Liste der hochgeladenen Fotos anzeigen",
   "show_failed_uploads_list": "Liste der fehlgeschlagenen Uploads anzeigen",
   "select_albums_for_auto_upload": "Alben für den automatischen Upload auswählen",
-  "share_photo_or_video": "Foto- oder Video-Datei teilen?"
+  "share_photo_or_video": "Foto- oder Video-Datei teilen?",
+  "list_default": "Bilder",
+  "list_archive": "Archiv",
+  "list_private": "Privat"
 }

--- a/assets/translations/de-DE.json
+++ b/assets/translations/de-DE.json
@@ -39,5 +39,11 @@
   "share_photo_or_video": "Foto- oder Video-Datei teilen?",
   "list_default": "Bilder",
   "list_archive": "Archiv",
-  "list_private": "Privat"
+  "list_private": "Privat",
+  "sort": "Sortierung",
+  "sort_order": "Richtung",
+  "filter": "Filter",
+  "TakenAt": "Aufnahme",
+  "UpdatedAt": "Aktualisierung",
+  "CreatedAt": "Erstellung"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -37,5 +37,8 @@
   "show_failed_uploads_list": "Show failed uploads list",
   "select_albums_for_auto_upload": "Select albums for auto-upload",
   "share_photo_or_video": "Do you want to share the photo file or the video file?",
-  "auto_upload_wifi_only": "Only automatically upload on Wi-Fi"
+  "auto_upload_wifi_only": "Only automatically upload on Wi-Fi",
+  "list_default": "Pictures",
+  "list_archive": "Archive",
+  "list_private": "Private"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -40,5 +40,11 @@
   "auto_upload_wifi_only": "Only automatically upload on Wi-Fi",
   "list_default": "Pictures",
   "list_archive": "Archive",
-  "list_private": "Private"
+  "list_private": "Private",
+  "sort": "Sort",
+  "sort_order": "Sort order",
+  "filter": "Filter",
+  "TakenAt": "Taken At",
+  "UpdatedAt": "Updated At",
+  "CreatedAt": "Created At"
 }

--- a/lib/common/db.dart
+++ b/lib/common/db.dart
@@ -117,9 +117,6 @@ class MyDatabase extends _$MyDatabase {
       case PhotoSort.CreatedAt:
         sortColumn = photos.createdAt;
         break;
-      case PhotoSort.TakenAt:
-        sortColumn = photos.takenAt;
-        break;
       case PhotoSort.UpdatedAt:
         sortColumn = photos.updatedAt;
         break;
@@ -127,8 +124,16 @@ class MyDatabase extends _$MyDatabase {
         sortColumn = photos.takenAt;
     }
 
-    if (filterPhotos.private == false) {
-      query = query..where(photos.private.not());
+    switch (filterPhotos.list) {
+      case PhotoList.Archive: 
+        query = query..where(photos.deletedAt.isNotNull());
+        break;
+      case PhotoList.Private:
+        query = query..where(photos.private);
+        break;
+      default: 
+        query = query..where(photos.deletedAt.isNull() & photos.private.not());
+        break;
     }
 
     return query
@@ -137,9 +142,6 @@ class MyDatabase extends _$MyDatabase {
           files.primary &
           files.error.equals('') &
           files.deletedAt.isNull() &
-          (filterPhotos.archived
-              ? photos.deletedAt.isNotNull()
-              : photos.deletedAt.isNull()) &
           photos.takenAt.isNotNull() &
           photos.type.isNotNull() &
           photos.type.isIn(filterPhotos.typesAsString))

--- a/lib/common/db.dart
+++ b/lib/common/db.dart
@@ -125,13 +125,13 @@ class MyDatabase extends _$MyDatabase {
     }
 
     switch (filterPhotos.list) {
-      case PhotoList.Archive: 
+      case PhotoList.Archive:
         query = query..where(photos.deletedAt.isNotNull());
         break;
       case PhotoList.Private:
         query = query..where(photos.private);
         break;
-      default: 
+      default:
         query = query..where(photos.deletedAt.isNull() & photos.private.not());
         break;
     }

--- a/lib/model/filter_photos.dart
+++ b/lib/model/filter_photos.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 enum PhotoSort { TakenAt, CreatedAt, UpdatedAt }
 enum PhotoType { Image, Live, Video }
+enum PhotoList { Default, Archive, Private }
 
 class FilterPhotos {
   FilterPhotos(
@@ -16,8 +17,7 @@ class FilterPhotos {
         PhotoType.Live,
         PhotoType.Video
       },
-      this.archived = false,
-      this.private = true}) {
+      this.list = PhotoList.Default}) {
     this.types = types.toSet();
   }
 
@@ -29,9 +29,7 @@ class FilterPhotos {
       types: (json['types'] as List<dynamic>)
           .map((dynamic v) =>
               EnumToString.fromString(PhotoType.values, v as String))
-          .toSet(),
-      archived: json['archived'] as bool,
-      private: json['private'] as bool,
+          .toSet()
     );
   }
 
@@ -59,16 +57,13 @@ class FilterPhotos {
         'sort': EnumToString.convertToString(sort),
         'types': types
             .map((PhotoType e) => EnumToString.convertToString(e))
-            .toList(),
-        'archived': archived,
-        'private': private,
+            .toList()
       };
 
   OrderingMode order = OrderingMode.desc;
   PhotoSort sort = PhotoSort.TakenAt;
   Set<PhotoType> types = <PhotoType>{PhotoType.Image, PhotoType.Live};
-  bool archived = false;
-  bool private = true;
+  PhotoList list = PhotoList.Default; 
 
   Iterable<String> get typesAsString =>
       EnumToString.toList(types.toList()).map((String s) => s.toLowerCase());

--- a/lib/model/filter_photos.dart
+++ b/lib/model/filter_photos.dart
@@ -23,14 +23,13 @@ class FilterPhotos {
 
   factory FilterPhotos.fromJson(Map<String, dynamic> json) {
     return FilterPhotos(
-      order:
-          EnumToString.fromString(OrderingMode.values, json['order'] as String),
-      sort: EnumToString.fromString(PhotoSort.values, json['sort'] as String),
-      types: (json['types'] as List<dynamic>)
-          .map((dynamic v) =>
-              EnumToString.fromString(PhotoType.values, v as String))
-          .toSet()
-    );
+        order: EnumToString.fromString(
+            OrderingMode.values, json['order'] as String),
+        sort: EnumToString.fromString(PhotoSort.values, json['sort'] as String),
+        types: (json['types'] as List<dynamic>)
+            .map((dynamic v) =>
+                EnumToString.fromString(PhotoType.values, v as String))
+            .toSet());
   }
 
   static Future<FilterPhotos> fromSharedPrefs() async {
@@ -55,15 +54,14 @@ class FilterPhotos {
   Map<String, dynamic> toJson() => <String, dynamic>{
         'order': EnumToString.convertToString(order),
         'sort': EnumToString.convertToString(sort),
-        'types': types
-            .map((PhotoType e) => EnumToString.convertToString(e))
-            .toList()
+        'types':
+            types.map((PhotoType e) => EnumToString.convertToString(e)).toList()
       };
 
   OrderingMode order = OrderingMode.desc;
   PhotoSort sort = PhotoSort.TakenAt;
   Set<PhotoType> types = <PhotoType>{PhotoType.Image, PhotoType.Live};
-  PhotoList list = PhotoList.Default; 
+  PhotoList list = PhotoList.Default;
 
   Iterable<String> get typesAsString =>
       EnumToString.toList(types.toList()).map((String s) => s.toLowerCase());

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -200,35 +200,35 @@ class PhotosPage extends StatelessWidget {
                   ),
                   PopupMenuItem<int>(
                     value: 1,
-                    child: const Text('filter_and_sort').tr(),
-                  ),
-                  PopupMenuItem<int>(
-                    value: 2,
                     child: const Text('list_default').tr()
                   ),
                   PopupMenuItem<int>(
-                    value: 3,
+                    value: 2,
                     child: const Text('list_archive').tr()
                   ),
                   PopupMenuItem<int>(
-                    value: 4,
+                    value: 3,
                     child: const Text('list_private').tr()
+                  ),
+                  PopupMenuItem<int>(
+                    value: 4,
+                    child: const Text('filter_and_sort').tr(),
                   )
                 ],
                 onSelected: (int choice) {
                   if (choice == 0) {
                     model.photoprismUploader.selectPhotoAndUpload(context);
                   } else if (choice == 1) {
-                    FilterPhotosDialog.show(context);
-                  } else if (choice == 2) {
                     model.filterPhotos.list = PhotoList.Default;
                     model.updatePhotosSubscription();
-                  } else if (choice == 3) {
+                  } else if (choice == 2) {
                     model.filterPhotos.list = PhotoList.Archive;
                     model.updatePhotosSubscription();
-                  } else if (choice == 4) {
+                  } else if (choice == 3) {
                     model.filterPhotos.list = PhotoList.Private;
                     model.updatePhotosSubscription();
+                  } else if (choice == 4) {
+                    FilterPhotosDialog.show(context);
                   }
                 },
               ),

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -11,6 +11,7 @@ import 'package:photoprism/common/db.dart';
 import 'package:photoprism/common/hexcolor.dart';
 import 'package:photoprism/common/photo_manager.dart';
 import 'package:photoprism/common/transparent_route.dart';
+import 'package:photoprism/model/filter_photos.dart';
 import 'package:photoprism/model/photoprism_model.dart';
 import 'package:photoprism/pages/photoview.dart';
 import 'package:draggable_scrollbar/draggable_scrollbar.dart';
@@ -200,6 +201,18 @@ class PhotosPage extends StatelessWidget {
                   PopupMenuItem<int>(
                     value: 1,
                     child: const Text('filter_and_sort').tr(),
+                  ),
+                  PopupMenuItem<int>(
+                    value: 2,
+                    child: const Text('list_default').tr()
+                  ),
+                  PopupMenuItem<int>(
+                    value: 3,
+                    child: const Text('list_archive').tr()
+                  ),
+                  PopupMenuItem<int>(
+                    value: 4,
+                    child: const Text('list_private').tr()
                   )
                 ],
                 onSelected: (int choice) {
@@ -207,6 +220,15 @@ class PhotosPage extends StatelessWidget {
                     model.photoprismUploader.selectPhotoAndUpload(context);
                   } else if (choice == 1) {
                     FilterPhotosDialog.show(context);
+                  } else if (choice == 2) {
+                    model.filterPhotos.list = PhotoList.Default;
+                    model.updatePhotosSubscription();
+                  } else if (choice == 3) {
+                    model.filterPhotos.list = PhotoList.Archive;
+                    model.updatePhotosSubscription();
+                  } else if (choice == 4) {
+                    model.filterPhotos.list = PhotoList.Private;
+                    model.updatePhotosSubscription();
                   }
                 },
               ),

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -199,17 +199,11 @@ class PhotosPage extends StatelessWidget {
                     child: const Text('upload_photo').tr(),
                   ),
                   PopupMenuItem<int>(
-                    value: 1,
-                    child: const Text('list_default').tr()
-                  ),
+                      value: 1, child: const Text('list_default').tr()),
                   PopupMenuItem<int>(
-                    value: 2,
-                    child: const Text('list_archive').tr()
-                  ),
+                      value: 2, child: const Text('list_archive').tr()),
                   PopupMenuItem<int>(
-                    value: 3,
-                    child: const Text('list_private').tr()
-                  ),
+                      value: 3, child: const Text('list_private').tr()),
                   PopupMenuItem<int>(
                     value: 4,
                     child: const Text('filter_and_sort').tr(),

--- a/lib/widgets/filter_photos_dialog.dart
+++ b/lib/widgets/filter_photos_dialog.dart
@@ -30,6 +30,57 @@ class _FilterPhotosDialogState extends State<FilterPhotosDialog> {
   PhotoprismModel model;
   FilterPhotos filter;
 
+  List<Widget> _sortOptions(BuildContext context) {
+    final List<Widget> sort = PhotoSort.values.map((PhotoSort e) => RadioListTile<PhotoSort>(
+      title: Text(EnumToString.convertToString(e).tr()),
+      dense: true,
+      value: e,
+      groupValue: filter.sort,
+      onChanged: (PhotoSort value) => setState(() { filter.sort = value; }),
+    )).toList();
+
+    final List<Widget> order = moor.OrderingMode.values.map((moor.OrderingMode e) => RadioListTile<moor.OrderingMode>(
+      title: Text(EnumToString.convertToString(e).tr()),
+      dense: true,
+      value: e,
+      groupValue: filter.order,
+      onChanged: (moor.OrderingMode value) => setState(() { filter.order = value; })
+    )).toList();
+    return <Widget>[
+      _dialogHeading('sort'.tr()),
+      ...sort,
+      _dialogHeading('sort_order'.tr()),
+      ...order
+    ];
+  }
+
+  List<Widget> _filterOptions(BuildContext context) {
+    return <Widget>[
+      _dialogHeading('filter'.tr()),
+      ...PhotoType.values.map((PhotoType e) => CheckboxListTile(
+                            title: Text(EnumToString.convertToString(e)),
+                            dense: true,
+                            contentPadding: const EdgeInsets.symmetric(horizontal: 25),
+                            onChanged: (bool value) {
+                              setState(() {
+                                if (value) {
+                                  filter.types.add(e);
+                                } else {
+                                  filter.types.remove(e);
+                                }
+                              });
+                            },
+                            value: filter.types.contains(e))).toList()
+    ];
+  }
+
+  Widget _dialogHeading(String title) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(25, 25, 10, 10),
+      child: Text(title)
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     Future<void> saveAndPop({bool asDefault}) async {
@@ -43,61 +94,16 @@ class _FilterPhotosDialogState extends State<FilterPhotosDialog> {
 
     return AlertDialog(
       title: const Text('filter_and_sort').tr(),
+      contentPadding: EdgeInsets.zero,
       content: SingleChildScrollView(
-          child: Column(
-        children: <Widget>[
-          DropdownButton<moor.OrderingMode>(
-            value: filter.order,
-            onChanged: (moor.OrderingMode newValue) {
-              setState(() {
-                filter.order = newValue;
-              });
-            },
-            items: moor.OrderingMode.values
-                .map<DropdownMenuItem<moor.OrderingMode>>(
-                    (moor.OrderingMode value) {
-              return DropdownMenuItem<moor.OrderingMode>(
-                value: value,
-                child: Text(EnumToString.convertToString(value)).tr(),
-              );
-            }).toList(),
-          ),
-          DropdownButton<PhotoSort>(
-            value: filter.sort,
-            onChanged: (PhotoSort newValue) {
-              setState(() {
-                filter.sort = newValue;
-              });
-            },
-            items: PhotoSort.values
-                .map<DropdownMenuItem<PhotoSort>>((PhotoSort value) {
-              return DropdownMenuItem<PhotoSort>(
-                value: value,
-                child: Text(EnumToString.convertToString(value)),
-              );
-            }).toList(),
-          ),
-          Container(
-              height: double.maxFinite,
-              width: double.maxFinite,
-              child: ListView.builder(
-                  itemCount: PhotoType.values.length,
-                  itemBuilder: (BuildContext context, int i) =>
-                      CheckboxListTile(
-                          title: Text(EnumToString.convertToString(
-                              PhotoType.values[i])),
-                          onChanged: (bool value) {
-                            setState(() {
-                              if (value) {
-                                filter.types.add(PhotoType.values[i]);
-                              } else {
-                                filter.types.remove(PhotoType.values[i]);
-                              }
-                            });
-                          },
-                          value: filter.types.contains(PhotoType.values[i])))),
-        ],
-      )),
+        child: Column(
+          children: <Widget>[
+            ..._sortOptions(context),
+            ..._filterOptions(context)
+          ],
+          crossAxisAlignment: CrossAxisAlignment.start,
+        )
+      ),
       actions: <Widget>[
         TextButton(
           child: const Text('cancel').tr(),

--- a/lib/widgets/filter_photos_dialog.dart
+++ b/lib/widgets/filter_photos_dialog.dart
@@ -46,24 +46,6 @@ class _FilterPhotosDialogState extends State<FilterPhotosDialog> {
       content: SingleChildScrollView(
           child: Column(
         children: <Widget>[
-          SwitchListTile(
-            title: const Text('archived').tr(),
-            onChanged: (bool value) {
-              setState(() {
-                filter.archived = value;
-              });
-            },
-            value: filter.archived,
-          ),
-          SwitchListTile(
-            title: const Text('private_photos').tr(),
-            onChanged: (bool value) {
-              setState(() {
-                filter.private = value;
-              });
-            },
-            value: filter.private,
-          ),
           DropdownButton<moor.OrderingMode>(
             value: filter.order,
             onChanged: (moor.OrderingMode newValue) {

--- a/lib/widgets/filter_photos_dialog.dart
+++ b/lib/widgets/filter_photos_dialog.dart
@@ -31,21 +31,28 @@ class _FilterPhotosDialogState extends State<FilterPhotosDialog> {
   FilterPhotos filter;
 
   List<Widget> _sortOptions(BuildContext context) {
-    final List<Widget> sort = PhotoSort.values.map((PhotoSort e) => RadioListTile<PhotoSort>(
-      title: Text(EnumToString.convertToString(e).tr()),
-      dense: true,
-      value: e,
-      groupValue: filter.sort,
-      onChanged: (PhotoSort value) => setState(() { filter.sort = value; }),
-    )).toList();
+    final List<Widget> sort = PhotoSort.values
+        .map((PhotoSort e) => RadioListTile<PhotoSort>(
+              title: Text(EnumToString.convertToString(e).tr()),
+              dense: true,
+              value: e,
+              groupValue: filter.sort,
+              onChanged: (PhotoSort value) => setState(() {
+                filter.sort = value;
+              }),
+            ))
+        .toList();
 
-    final List<Widget> order = moor.OrderingMode.values.map((moor.OrderingMode e) => RadioListTile<moor.OrderingMode>(
-      title: Text(EnumToString.convertToString(e).tr()),
-      dense: true,
-      value: e,
-      groupValue: filter.order,
-      onChanged: (moor.OrderingMode value) => setState(() { filter.order = value; })
-    )).toList();
+    final List<Widget> order = moor.OrderingMode.values
+        .map((moor.OrderingMode e) => RadioListTile<moor.OrderingMode>(
+            title: Text(EnumToString.convertToString(e).tr()),
+            dense: true,
+            value: e,
+            groupValue: filter.order,
+            onChanged: (moor.OrderingMode value) => setState(() {
+                  filter.order = value;
+                })))
+        .toList();
     return <Widget>[
       _dialogHeading('sort'.tr()),
       ...sort,
@@ -57,28 +64,28 @@ class _FilterPhotosDialogState extends State<FilterPhotosDialog> {
   List<Widget> _filterOptions(BuildContext context) {
     return <Widget>[
       _dialogHeading('filter'.tr()),
-      ...PhotoType.values.map((PhotoType e) => CheckboxListTile(
-                            title: Text(EnumToString.convertToString(e)),
-                            dense: true,
-                            contentPadding: const EdgeInsets.symmetric(horizontal: 25),
-                            onChanged: (bool value) {
-                              setState(() {
-                                if (value) {
-                                  filter.types.add(e);
-                                } else {
-                                  filter.types.remove(e);
-                                }
-                              });
-                            },
-                            value: filter.types.contains(e))).toList()
+      ...PhotoType.values
+          .map((PhotoType e) => CheckboxListTile(
+              title: Text(EnumToString.convertToString(e)),
+              dense: true,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 25),
+              onChanged: (bool value) {
+                setState(() {
+                  if (value) {
+                    filter.types.add(e);
+                  } else {
+                    filter.types.remove(e);
+                  }
+                });
+              },
+              value: filter.types.contains(e)))
+          .toList()
     ];
   }
 
   Widget _dialogHeading(String title) {
     return Container(
-      margin: const EdgeInsets.fromLTRB(25, 25, 10, 10),
-      child: Text(title)
-    );
+        margin: const EdgeInsets.fromLTRB(25, 25, 10, 10), child: Text(title));
   }
 
   @override
@@ -96,14 +103,13 @@ class _FilterPhotosDialogState extends State<FilterPhotosDialog> {
       title: const Text('filter_and_sort').tr(),
       contentPadding: EdgeInsets.zero,
       content: SingleChildScrollView(
-        child: Column(
-          children: <Widget>[
-            ..._sortOptions(context),
-            ..._filterOptions(context)
-          ],
-          crossAxisAlignment: CrossAxisAlignment.start,
-        )
-      ),
+          child: Column(
+        children: <Widget>[
+          ..._sortOptions(context),
+          ..._filterOptions(context)
+        ],
+        crossAxisAlignment: CrossAxisAlignment.start,
+      )),
       actions: <Widget>[
         TextButton(
           child: const Text('cancel').tr(),


### PR DESCRIPTION
I did this in preparation for a sectioned photos page. I wanted to provide options to group the photos by day, month or not at all. Later I realised the grouping is a bit more work than I thought :D

I added options to the action bar to switch between different lists to display (default, archive, private). I removed the selection boxes in the sort and filter dialog and inserted radio buttons.

I'm not happy with the wording of the "default" list, so I'm open for suggestions :)

Will hopefully add the sectioned grid view with a later PR.